### PR TITLE
feature/add-props-to-renderComponent

### DIFF
--- a/example/Example6.svelte
+++ b/example/Example6.svelte
@@ -1,9 +1,12 @@
 <script>
   import SvelteTable from "../src/SvelteTable.svelte";
   import ContactButtonComponent from "./example6/ContactButtonComponent.svelte";
+  import HelpButtonComponent from "./example6/HelpButtonComponent.svelte";
   // import SvelteTable from "svelte-table";
   import faker from "faker";
   faker.seed(15);
+
+  const onContactButtonClick = row => alert(`Contacted ${row.first_name} ${row.last_name}`);
 
   const colums = [
     {
@@ -35,10 +38,16 @@
       class: "text-center"
     },
     {
-      key: "actions",
+      key: "contact",
       title: "",
       sortable: false,
-      renderComponent: ContactButtonComponent
+      renderComponent: {component: ContactButtonComponent, props: {onContactButtonClick}}
+    },
+    {
+      key: "help",
+      title: "",
+      sortable: false,
+      renderComponent: {component: HelpButtonComponent, props: {onContactButtonClick}}
     },
   ];
 

--- a/example/example6/ContactButtonComponent.svelte
+++ b/example/example6/ContactButtonComponent.svelte
@@ -1,6 +1,6 @@
 <script>
   export let row;
-  export let col;
+  export let onContactButtonClick;
 </script>
 
-<button on:click={() => alert(`Contacted ${row.first_name} ${row.last_name}`)}>Contact</button>
+<button on:click={() => onContactButtonClick(row)}>Contact {row.first_name} {row.last_name}</button>

--- a/example/example6/HelpButtonComponent.svelte
+++ b/example/example6/HelpButtonComponent.svelte
@@ -1,0 +1,1 @@
+<button on:click={() => alert('Read the svelte-table docs: https://github.com/dasDaniel/svelte-table')}>Help</button>

--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -180,7 +180,7 @@
               class={asStringArray([col.class, classNameCell])}
             >
               {#if col.renderComponent}
-                <svelte:component this={col.renderComponent} row={row}/>
+                <svelte:component this={col.renderComponent.component} {...(col.renderComponent.props || {})} row={row}/>
               {:else}
                 {@html col.renderValue ? col.renderValue(row) : col.value(row)}
               {/if}


### PR DESCRIPTION
This is a follow up to https://github.com/dasDaniel/svelte-table/pull/21.

When I used the new `renderComponent` feature in my project, I realized there is no way to pass in props to the component.
The most important use case I see for this issue is an event handler, e.g. to handle `on:click`.

I therefore changed the api:

**Old api:**

```
{
  renderComponent: <SvelteComponent>
}
```

**New api:**

```
{
  renderComponent: {
    component: <SvelteComponent>,
    props?: Object
  }
}
```

**How it works in SvelteTable.svelte:**

- Uses [spread-props](https://svelte.dev/tutorial/spread-props)
- props is optional, undefined case is handled with `props || {}`

```
{#if col.renderComponent}
   <svelte:component this={col.renderComponent.component} {...(col.renderComponent.props || {})} row={row}/>
{:else}
...
```

**Event handler example:**

```
const onContactButtonClick = row => alert(`Contacted ${row.first_name} ${row.last_name}`);
...
{
      key: "contact",
      title: "",
      sortable: false,
      renderComponent: {component: ContactButtonComponent, props: {onContactButtonClick}} // add event handler
}
```

```
<script>
  export let row;
  export let onContactButtonClick;
</script>

<button on:click={() => onContactButtonClick(row)}>Contact {row.first_name} {row.last_name}</button> // use event handler with row.
```

I also updated the existing Example 6 to cover both the props and no props case.

Let me know what you think.