### PR TITLE
Support HTML strings in icon indicator props

### DIFF
--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -250,7 +250,7 @@
           >
             {col.title}
             {#if sortBy === col.key}
-              {sortOrder === 1 ? iconAsc : iconDesc}
+              {@html sortOrder === 1 ? iconAsc : iconDesc}
             {/if}
           </th>
         {/each}
@@ -297,7 +297,7 @@
               on:click={e => handleClickExpand(e, row)}
               class={asStringArray(["isClickable", classNameCellExpand])}
             >
-              {row.$expanded ? iconExpand : iconExpanded}
+              {@html row.$expanded ? iconExpand : iconExpanded}
             </td>
           {/if}
         </tr>


### PR DESCRIPTION
Adds support for HTML strings when setting `iconAsc`, `iconDesc`, `iconExpand`, `iconExpanded` table properties.

Example:

```html
<SvelteTable 
  ...
  iconAsc="<i class='icon-arrow-down'></i>"
  iconDesc="<i class='icon-arrow-up'></i>"
```