### PR TITLE
[ST-076] classNameInput and headerFilterClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.4
+
+- Add `classNameInput` prop and a `headerFilterClass` column object key [#76](https://github.com/dasDaniel/svelte-table/issues/76)
+
 ## 0.3.3
 
 - Customize sort order using `sortOrders` prop [#73](https://github.com/dasDaniel/svelte-table/issues/73)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,8 @@ const columns = [
 | `classNameTable`           | String/Array | _optional_ class name(s) for table element                  |
 | `classNameThead`           | String/Array | _optional_ class name(s) for thead element                  |
 | `classNameTbody`           | String/Array | _optional_ class name(s) for tbody element                  |
-| `classNameSelect`          | String/Array | _optional_ class name(s) for select elements                |
+| `classNameSelect`          | String/Array | _optional_ class name(s) for filter select elements         |
+| `classNameInput`           | String/Array | _optional_ class name(s) for search input elements          |
 | `classNameRow`             | String/Array | _optional_ class name(s) for row elements                   |
 | `classNameRowExpanded`     | String/Array | _optional_ class name(s) for expanded row                   |
 | `classNameExpandedContent` | String/Array | _optional_ class name(s) for expanded row content           |
@@ -254,19 +255,20 @@ example: (will preset column with key `first_name` to `a`)
 
 ## Column array object values
 
-| Option              | Type           | Description                                                                                                   |
-| ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
-| `key`               | String         | Unique key identifying the column                                                                             |
-| `title`             | String         | Title for header                                                                                              |
-| `value`             | Function       | table cell value. The function is passed row data                                                             |
-| `[class]`           | String         | _optional_ table cell class name                                                                              |
-| `[sortable]`        | Boolean        | _optional_ Whether the table can be sorted on column                                                          |
-| `[searchValue]`     | Function       | _optional_ search value function. function is passed row data.                                                |
-| `[filterOptions]`   | Array/Function | _optional_ array of objects with `name` and `value`. Function is provided array of rows                       |
-| `[filterValue]`     | String         | _optional_ value to filter on, usually same as value                                                          |
-| `[headerClass]`     | String         | _optional_ class to assign to header                                                                          |
-| `[renderValue]`     | Function       | _optional_ render function for rendering html content                                                         |
-| `[renderComponent]` | Component      | _optional_ pass a Svelte component, component will receive `row` and `col` variables (replaces `renderValue`) |
+| Option                | Type           | Description                                                                                                   |
+| --------------------- | -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `key`                 | String         | Unique key identifying the column                                                                             |
+| `title`               | String         | Title for header                                                                                              |
+| `value`               | Function       | table cell value. The function is passed row data                                                             |
+| `[class]`             | String         | _optional_ table cell class name                                                                              |
+| `[sortable]`          | Boolean        | _optional_ Whether the table can be sorted on column                                                          |
+| `[searchValue]`       | Function       | _optional_ search value function. function is passed row data.                                                |
+| `[filterOptions]`     | Array/Function | _optional_ array of objects with `name` and `value`. Function is provided array of rows                       |
+| `[filterValue]`       | String         | _optional_ value to filter on, usually same as value                                                          |
+| `[headerClass]`       | String         | _optional_ class to assign to header element                                                                  |
+| `[headerFilterClass]` | String         | _optional_ class to assign to search/filter header element                                                    |
+| `[renderValue]`       | Function       | _optional_ render function for rendering html content                                                         |
+| `[renderComponent]`   | Component      | _optional_ pass a Svelte component, component will receive `row` and `col` variables (replaces `renderValue`) |
 
 ### renderComponent
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-table",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-table",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "repository": "dasDaniel/svelte-table",
   "module": "dist/es/SvelteTable.mjs",

--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -67,6 +67,9 @@
   export let classNameSelect = "";
 
   /** @type {string} */
+  export let classNameInput = "";
+
+  /** @type {string} */
   export let classNameRow = "";
 
   /** @type {string} */
@@ -227,9 +230,12 @@
     {#if showFilterHeader}
       <tr>
         {#each columns as col}
-          <th>
+          <th class={asStringArray([col.headerFilterClass])}>
             {#if col.searchValue !== undefined}
-              <input bind:value={filterSelections[col.key]} />
+              <input
+                bind:value={filterSelections[col.key]}
+                class={asStringArray(classNameInput)}
+              />
             {:else if filterValues[col.key] !== undefined}
               <select
                 bind:value={filterSelections[col.key]}


### PR DESCRIPTION
- Added `classNameInput` prop and a `headerFilterClass` column object key [#76](https://github.com/dasDaniel/svelte-table/issues/76)