### PR TITLE
Add "classNameRowSelected" and "key" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ const columns = [
 
 | Option                     | Type         | Description                                                 |
 | -------------------------- | ------------ | ----------------------------------------------------------- |
+| `key`                      | String       | _optional/recommended_ the name of the unique value of rows, it help SvelteTable keep track of data and do rendering optimization |
 | `columns`                  | Object[]     | column config (details below)                               |
 | `rows`                     | Object[]     | row (data) array                                            |
 | `sortBy`                   | String       | ‡ Sorting key                                               |
@@ -183,6 +184,7 @@ const columns = [
 | `classNameSelect`          | String/Array | _optional_ class name(s) for filter select elements         |
 | `classNameInput`           | String/Array | _optional_ class name(s) for search input elements          |
 | `classNameRow`             | String/Array | _optional_ class name(s) for row elements                   |
+| `classNameRowSelected`     | String/Array | _optional_ class name(s) for selected row, this option requires 'key' option |
 | `classNameRowExpanded`     | String/Array | _optional_ class name(s) for expanded row                   |
 | `classNameExpandedContent` | String/Array | _optional_ class name(s) for expanded row content           |
 | `classNameCell`            | String/Array | _optional_ class name(s) for cell elements                  |

--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -30,6 +30,9 @@
 
   // READ ONLY
 
+  /** @type {string} used for rendering optimization */
+  export let key = null;
+
   /** @type {string} */
   export let expandRowKey = null;
 
@@ -75,6 +78,9 @@
   /** @type {string} */
   export let classNameCell = "";
 
+  /** @type {string} class added to the selected row*/
+  export let classNameRowSelected = "";
+
   /** @type {string} class added to the expanded row*/
   export let classNameRowExpanded = "";
 
@@ -84,12 +90,15 @@
   /** @type {string} class added to the cell that allows expanding/closing */
   export let classNameCellExpand = "";
 
+  let selectedRow = null;
+
   const dispatch = createEventDispatcher();
 
   let sortFunction = () => "";
 
   // Validation
   if (!Array.isArray(expanded)) throw "'expanded' needs to be an array";
+  if (classNameRowSelected && !key) console.warn("'key' is needed to use 'classNameRowSelected'");
 
   let showFilterHeader = columns.some(c => {
     // check if there are any filter or search headers
@@ -202,6 +211,7 @@
   };
 
   const handleClickRow = (event, row) => {
+    selectedRow = row;
     dispatch("clickRow", { event, row });
   };
 
@@ -289,6 +299,7 @@
           class={asStringArray([
             classNameRow,
             row.$expanded && classNameRowExpanded,
+            key && (row[key] === selectedRow?.[key]) && classNameRowSelected,
           ])}
         >
           {#each columns as col}


### PR DESCRIPTION
`classNameRowSelected` helps injecting css classes to the selected row.

Because the `svelte-table` renders a filtered-copy (`c_rows` variable) of the data source, adding an extended field to indicate the `selected` state to the copy is not a good idea because whenever the source data is changed, the copy will be updated and it will lose the extended field. Adding an extended field to the source data is not a good solution as well, because it cause an entire re-render to the table.
So adding `key` option to help SvelteTable keep track of row identity to do comparisons is a good idea, like the way Reactjs use `key` prop when rendering a list or Vuejs use `key` prop when using `v-for`.

It only re-renders the selected rows:
![Jun-18-2022 21-49-25](https://user-images.githubusercontent.com/22351393/174445261-59fba438-90be-4ba9-9583-67ac030f9657.gif)


