### PR TITLE
Adding small change to the types

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,7 @@
 export type TableColumn<T> = {
   key: string | number;
   title: string;
-  value: (row: T) => string | number;
+  value?: (row: T) => string | number;
   class?:
     | string
     | ((row: T, rowIndex?: number, colIndex?: number) => string | null);


### PR DESCRIPTION
This change would allow the `Example6.svelte` to function properly when adding typescript to the mix. Currently, since `value` field of `TableColumns<T>` is non-nullable, `Example6.svelte` does not work since it is missing the value field for either button. I added in the question mark to the `value` field to allow it to be nullable and fix this issue.

Also, this is my first time contributing to an open source project so please let me know if I am doing anything weird. Thanks!