### PR TITLE
support alternate sortValue in column config

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ example: (will preset column with key `first_name` to `a`)
 | `value`               | Function       | table cell value. The function is passed row data                                                             |
 | `[class]`             | String         | _optional_ table cell class name                                                                              |
 | `[sortable]`          | Boolean        | _optional_ Whether the table can be sorted on column                                                          |
+| `[sortValue]`         | Function       | _optional_ alternate sort value function. function is passed row data.                                        |
 | `[searchValue]`       | Function       | _optional_ search value function. function is passed row data.                                                |
 | `[filterOptions]`     | Array/Function | _optional_ array of objects with `name` and `value`. Function is provided array of rows                       |
 | `[filterValue]`       | String         | _optional_ value to filter on, usually same as value                                                          |
@@ -315,6 +316,19 @@ Or, if props need to be passed, an object with `component` and `props` can be pa
         myProp: "someValue",
       },
     },
+  },
+];
+```
+
+You can also assign an alternate sort value to any column using a component
+
+```js
+[
+  {
+    key: "myColumn",
+    //...
+    sortValue: row => row.someValueUsedToSort,
+    renderComponent: myComponent,
   },
 ];
 ```

--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -195,12 +195,13 @@
 
   $: {
     let col = columnByKey[sortBy];
+
     if (
       col !== undefined &&
       col.sortable === true &&
-      typeof col.value === "function"
+      (typeof col.value === "function" || typeof col.sortValue === "function")
     ) {
-      sortFunction = r => col.value(r);
+      sortFunction = r => (col.sortValue ? col.sortValue(r) : col.value(r));
     }
   }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ export type TableColumn<T> = {
     | string
     | ((row: T, rowIndex?: number, colIndex?: number) => string | null);
   sortable?: boolean;
+  sortValue?: (row: T) => string | number;
   searchValue?: (row: T) => string | number;
   filterOptions?: ((row: T) => any) | any[];
   filterValue?: (row: T) => any;


### PR DESCRIPTION
Introduces a new column config method `sortValue` that allows the user to assign an alternate sort value to the column. This is helpful when using components for cell rendering but you would like to still have the ability to sort.

```js
[
  {
    key: "myColumn",
    //...
    sortValue: (row) => row.someValueUsedToSort,
    renderComponent: myComponent
  },
];
```