### PR TITLE
feat!: escape html for renderValue and value content by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ example: (will preset column with key `first_name` to `a`)
 | `[headerFilterClass]` | String         | _optional_ class to assign to search/filter header element                                             |
 | `[renderValue]`       | Function       | _optional_ render function for rendering html content                                                  |
 | `[renderComponent]`   | Component      | _optional_ pass a Svelte component, it will receive `row` and `col` variables (replaces `renderValue`) |
+| `[parseHTML]`         | Boolean        | _optional_ if true, it will render the cell value with `@html`                                         |
 
 ### `searchValue`
 

--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -390,8 +390,12 @@
                   {row}
                   {col}
                 />
-              {:else}
+              {:else if col.parseHTML}
                 {@html col.renderValue
+                  ? col.renderValue(row, n, colIndex)
+                  : col.value(row, n, colIndex)}
+              {:else}
+                {col.renderValue
                   ? col.renderValue(row, n, colIndex)
                   : col.value(row, n, colIndex)}
               {/if}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,6 +19,7 @@ export type TableColumn<T> = {
   headerClass?: string;
   headerFilterClass?: string;
   renderValue?: (row: T, rowIndex?: number, colIndex?: number) => any;
+  parseHTML: boolean;
   renderComponent?: any; // svelte component
   hideFilterHeader?: boolean;
 };


### PR DESCRIPTION
if you currently do rendering with either `value` or `renderValue` you have to manually escape your html because its always rendered with the html tags, which doesnt perform sanitization of the expression (https://svelte.dev/tutorial/html-tags).

This can be worked around with the slot interface but that would result in a lot of additional code (at least in my code base) or it would result in the user manually doing sanitization, which isn't great for users.

This is a breaking change because it now uses sanitization by default and you have to opt out of it but i understand if you dont wanna break here, if thats the case we can make sanitization opt in. Afaik jquery-datatables also has a sanitization opt in and not on by default.

