### PR TITLE
Define parseHTML property as optional

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -19,7 +19,7 @@ export type TableColumn<T> = {
   headerClass?: string;
   headerFilterClass?: string;
   renderValue?: (row: T, rowIndex?: number, colIndex?: number) => any;
-  parseHTML: boolean;
+  parseHTML?: boolean;
   renderComponent?: any; // svelte component
   hideFilterHeader?: boolean;
 };


### PR DESCRIPTION
Happy to see the breaking change in the name of security, but the TS definition in #158 defines the parseHTML property as required. This causes the type checker to complain about any columns missing the property.