### PR TITLE
added #key before rendering col.renderComponent

### DIFF
--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -383,22 +383,24 @@
                 classNameCell,
               ])}
             >
-              {#if col.renderComponent}
-                <svelte:component
-                  this={col.renderComponent.component || col.renderComponent}
-                  {...col.renderComponent.props || {}}
-                  {row}
-                  {col}
-                />
-              {:else if col.parseHTML}
-                {@html col.renderValue
-                  ? col.renderValue(row, n, colIndex)
-                  : col.value(row, n, colIndex)}
-              {:else}
-                {col.renderValue
-                  ? col.renderValue(row, n, colIndex)
-                  : col.value(row, n, colIndex)}
-              {/if}
+              {#key c_rows}
+                {#if col.renderComponent}
+                  <svelte:component
+                    this={col.renderComponent.component || col.renderComponent}
+                    {...col.renderComponent.props || {}}
+                    {row}
+                    {col}
+                  />
+                {:else if col.parseHTML}
+                  {@html col.renderValue
+                    ? col.renderValue(row, n, colIndex)
+                    : col.value(row, n, colIndex)}
+                {:else}
+                  {col.renderValue
+                    ? col.renderValue(row, n, colIndex)
+                    : col.value(row, n, colIndex)}
+                {/if}
+              {/key}
             </td>
           {/each}
           {#if showExpandIcon}


### PR DESCRIPTION
Custom component that are passed using the `renderComponent` prop are not updating after changes occurred when using filters on other columns.  

Wrapping the code in {#key c_rows} {/key} fixes the issue. 

```svelte
              {#key c_rows}
                {#if col.renderComponent}
                  <svelte:component
                    this={col.renderComponent.component || col.renderComponent}
                    {...col.renderComponent.props || {}}
                    {row}
                    {col}
                  />
                {:else if col.parseHTML}
                  {@html col.renderValue
                    ? col.renderValue(row, n, colIndex)
                    : col.value(row, n, colIndex)}
                {:else}
                  {col.renderValue
                    ? col.renderValue(row, n, colIndex)
                    : col.value(row, n, colIndex)}
                {/if}
              {/key}
```