### PR TITLE
Add export for vite-plugin-svelte@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "module": "dist/es/SvelteTable.mjs",
   "main": "dist/umd/SvelteTable.js",
   "svelte": "src/SvelteTable.svelte",
+  "exports": {
+    ".": {
+      "svelte": "./src/SvelteTable.svelte"
+    }
+  },
   "types": "src/types.ts",
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
In `vite-plugin-svelte@3`, the `svelte` field in `package.json` is deprecated. It now requires a `svelte` export condition.

I have not tested this with any other build systems.

References from [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte/tree/main):
- [FAQ: missing export condition](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition)
- [Release notes](https://github.com/sveltejs/vite-plugin-svelte/releases/tag/%40sveltejs%2Fvite-plugin-svelte%403.0.0)
- [Original pull request](https://github.com/sveltejs/vite-plugin-svelte/pull/747)